### PR TITLE
update siteurl.

### DIFF
--- a/publishconf.py
+++ b/publishconf.py
@@ -11,7 +11,7 @@ sys.path.append(os.curdir)
 from pelicanconf import *
 
 # If your site is available via HTTPS, make sure SITEURL begins with https://
-SITEURL = 'https://blog.pandas.io'
+SITEURL = 'https://dev.pandas.io/pandas-blog'
 RELATIVE_URLS = True
 
 FEED_ALL_ATOM = 'feeds/all.atom.xml'


### PR DESCRIPTION
cc @wesm, @datapythonista.

I've already pushed this. I think the link from https://pandas.pydata.org/community/blog.html will be fixed on the next commit to pandas master